### PR TITLE
Don't set width to parent width because it truncates report names

### DIFF
--- a/css/catalog_viewer.css
+++ b/css/catalog_viewer.css
@@ -217,7 +217,7 @@ div.acked, li.list-group-item.acked {
   height: 50px;
 }
 .dropdown-menu {
-  width: 100%;
+  width: fit-content
 }
 .scrollable-menu {
   height: auto;


### PR DESCRIPTION
👋🏻  Very small PR incoming!

Currently, the report list width is set to that of the parent. This creates a significant problem for reports with longer names, as depicted below:

![Screenshot 2022-08-24 at 20 05 34](https://user-images.githubusercontent.com/39983886/186491130-22e6b326-3b94-4c35-9e86-7e36b51dc90b.png)

This PR aims to address it. Example output showcasing PR change:

![Screenshot 2022-08-24 at 20 09 10](https://user-images.githubusercontent.com/39983886/186491770-64dfdafa-32ba-48e5-9003-059edb4e9eea.png)

It also expands the width based a the report name length. Example with super long report name:

![Screenshot 2022-08-24 at 20 07 07](https://user-images.githubusercontent.com/39983886/186491399-ec6b9efd-6ad6-4626-8605-eec03fb87e87.png)

Any comments are welcome!