### PR TITLE
update readme and test container build

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: voxpupuli/gha-build-and-publish-a-container@e8eaaaa2b02fdd2bf0f47c5cb07f120353e5ecf4
+      - uses: voxpupuli/gha-build-and-publish-a-container@6cc48dfef0d27070922d8adbd661884de1dd45c8
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_arch: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 Puppet Catalog Diff Viewer
 ===========================
 
-[![License](https://img.shields.io/github/license/camptocamp/puppet-catalog-diff-viewer.svg)](https://github.com/camptocamp/puppet-catalog-diff-viewer/blob/master/LICENSE)
-[![Docker Pulls](https://img.shields.io/docker/pulls/camptocamp/puppet-catalog-diff-viewer.svg)](https://hub.docker.com/r/camptocamp/puppet-catalog-diff-viewer/)
-[![Build Status](https://img.shields.io/travis/camptocamp/puppet-catalog-diff-viewer/master.svg)](https://travis-ci.org/camptocamp/puppet-catalog-diff-viewer)
-[![By Camptocamp](https://img.shields.io/badge/by-camptocamp-fb7047.svg)](http://www.camptocamp.com)
+[![License](https://img.shields.io/github/license/voxpupuli/puppet-catalog-diff-viewer.svg)](https://github.com/voxpupuli/puppet-catalog-diff-viewer/blob/master/LICENSE)
+[![CI](https://github.com/voxpupuli/puppet-catalog-diff-viewer/actions/workflows/ci.yaml/badge.svg)](https://github.com/voxpupuli/puppet-catalog-diff-viewer/actions/workflows/ci.yaml)
 
 
 A viewer for json reports produced by [the puppet-catalog-diff tool](https://github.com/voxpupuli/puppet-catalog-diff)


### PR DESCRIPTION
- remove camptocamp references in badge icons
- remove docker hub pulls, we are now on ghcr, but they don't have a badge for that, yet
- update ci status badge
- trigger container build with this change and so test the last PR #50 