### PR TITLE
github_changelog_generator: Add optional faraday dependency and version constraints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ gem 'docker-api', require: false
 gem 'serverspec', require: false
 
 group :release do
-  gem 'github_changelog_generator', '>= 1.16.1', require: false
+  gem 'faraday-retry', '~> 2.2', require: false
+  gem 'github_changelog_generator', '~> 1.16', '>= 1.16.4', require: false
 end


### PR DESCRIPTION
latest github_changelog_generator versions raise a warning when faraday isn't installed, so we need to add it to the Gemfile. We've done the same on other Gems.